### PR TITLE
Update url_unshortener.py

### DIFF
--- a/url_unshortener.py
+++ b/url_unshortener.py
@@ -12,10 +12,9 @@ class UnsupportedURLError(Exception):
 
 
 def tinyurl_process(path):
-    hosted_url = requests.get(f"http://tinyurl.com/{path}")
-    soup = BeautifulSoup(hosted_url.history[0].text,"html.parser")
-    return soup.a["href"]
-
+    hosted_url = requests.get(f"https://preview.tinyurl.com/{path}")
+    soup = BeautifulSoup(hosted_url.text, "html.parser")
+    return soup.find(id="redirecturl")['href']
 
 
 def bitly_process(path):


### PR DESCRIPTION
This hopefully avoids the problem of variable preview pages for tiny url. The issue is that there are two possible options: www.tinyurl.com/example -> example.com and www.tinyurl.com/example -> preview.tinyurl.com/example -> example.com.
The tinyurl_process would return example.com for the first, and preview.tinyurl.com/example for the second. This process needs more attention than I expected. Edit: this was implemented by changing the first option from www.tinyurl.com/example -> example.com to preview.tinyurl.com/example -> example.com by doing www.tinyurl.com/example -> preview.tinyurl.com/example.